### PR TITLE
Fix Dependabot workflow approval issue

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,16 +16,9 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       
-      - name: Auto-approve for patch and minor updates
+      - name: Comment to trigger Dependabot merge for patch and minor updates
         if: ${{ contains(fromJSON('["version-update:semver-patch", "version-update:semver-minor"]'), steps.metadata.outputs.update-type) }}
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Enable auto-merge for patch and minor updates
-        if: ${{ contains(fromJSON('["version-update:semver-patch", "version-update:semver-minor"]'), steps.metadata.outputs.update-type) }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr comment "$PR_URL" --body "@dependabot merge"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fix the Dependabot auto-merge workflow that was failing due to GitHub Actions permission limitations.

## Problem
The current workflow tries to use `gh pr review --approve` which fails with:
```
GitHub Actions is not permitted to approve pull requests. (addPullRequestReview)
```

## Solution
- Replace direct PR approval/merge with `@dependabot merge` comment
- This leverages Dependabot's built-in merge capability
- Cleaner and follows GitHub's recommended approach

## Changes
- Use `gh pr comment` with `@dependabot merge` instead of direct approval
- Remove unnecessary auto-merge step since Dependabot handles it

🤖 Generated with [Claude Code](https://claude.ai/code)